### PR TITLE
Fix macOS builds to support both Intel and Apple Silicon architectures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   Linux-App:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: |
           rustup set auto-self-update disable
           rustup toolchain install stable --profile minimal
@@ -44,7 +44,7 @@ jobs:
   Windows-App:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: win32
@@ -67,27 +67,84 @@ jobs:
           path: target/i686-pc-windows-msvc/release/*.exe
 
   OSX-app:
-    runs-on: macos-latest # X86 since M1 can use rosetta to run this
+    runs-on: macos-latest # macos-latest is macOS 15 on Apple Silicon (ARM64) as of 2025
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install stable --profile minimal
+      - name: Add Rust targets for Universal Binary
+        run: |
+          rustup target add x86_64-apple-darwin
+          rustup target add aarch64-apple-darwin
+      - name: Install build dependencies
+        run: |
+          # Ensure we have necessary build tools for OpenSSL compilation
+          which perl || brew install perl
+          which make || echo "make already available"
       - name: Install cargo-bundle
         run: cargo install cargo-bundle
       - uses: Swatinem/rust-cache@v2
-      - name: Build executable
+        with:
+          key: "v2-macos-universal-static-ssl"
+      - name: Build for x86_64 (Intel)
+        run: cargo build --release --target x86_64-apple-darwin --package config_app
+        env:
+          # Enable verbose OpenSSL build output for debugging
+          OPENSSL_STATIC: "1"
+      - name: Build for aarch64 (Apple Silicon)
+        run: cargo build --release --target aarch64-apple-darwin --package config_app
+        env:
+          OPENSSL_STATIC: "1"
+      - name: Create Universal Binary
         run: |
+          mkdir -p target/release
+          lipo -create \
+            target/x86_64-apple-darwin/release/config_app \
+            target/aarch64-apple-darwin/release/config_app \
+            -output target/release/config_app
+          echo "Universal binary created. Verifying architectures:"
+          lipo -info target/release/config_app
+      # TODO: Code signing with Apple Developer Certificate
+      # Requires: Apple Developer Account ($99/year) and certificates in GitHub Secrets
+      # Uncomment and configure the following steps when certificate is available:
+      #
+      # - name: Import Code Signing Certificate
+      #   env:
+      #     MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+      #     MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+      #   run: |
+      #     echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+      #     security create-keychain -p actions temp.keychain
+      #     security default-keychain -s temp.keychain
+      #     security unlock-keychain -p actions temp.keychain
+      #     security import certificate.p12 -k temp.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
+      #     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k actions temp.keychain
+      #
+      # - name: Sign Application Binary
+      #   run: |
+      #     codesign --force --deep \
+      #       --sign "Developer ID Application: YOUR_NAME (TEAM_ID)" \
+      #       --options runtime \
+      #       --timestamp \
+      #       target/release/config_app
+      #
+      # For now, users need to remove quarantine attribute after download:
+      # xattr -cr Ultimate-NAG52-Config-App.app
+      - name: Create .app bundle with cargo-bundle
+        run: |
+          # cargo-bundle expects binary in target/release/
           cargo bundle --release --package config_app
-          ls target/release/bundle/
+          echo "Bundle contents:"
+          ls -R target/release/bundle/osx/
       - uses: actions/upload-artifact@v4
         with:
           name: config-app-osx
           path: target/release/bundle/osx/*.app
 
   Create-Upload:
-    needs: [Windows-App, Linux-App, OSX-app] #, 
-    runs-on: [ubuntu-latest]
+    needs: [Windows-App, Linux-App, OSX-app]
+    runs-on: ubuntu-latest
     steps:
     - name: Download Windows artifact
       uses: actions/download-artifact@v4
@@ -103,24 +160,15 @@ jobs:
         name: config-app-osx
     - name: View artifacts
       run: ls -R
-    - name: create release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ env.BRANCH_NAME }}-${{ github.sha }}
-        release_name: Release ${{ env.BRANCH_NAME }}
-        draft: false
-        prerelease: ${{env.BRANCH_NAME}} != "main"
-    - name: Upload all apps
-      id: upload-release-asset 
-      uses: softprops/action-gh-release@v1
+    - name: Create release and upload assets
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ env.BRANCH_NAME }}-${{ github.sha }}
         name: Release ${{ env.BRANCH_NAME }}
+        draft: false
+        prerelease: ${{ env.BRANCH_NAME != 'main' }}
         files: |
           *.exe
           *.AppImage

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,7 @@ jobs:
   deploy_docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - run: |
-          rustup set auto-self-update disable
-          rustup toolchain install stable --profile minimal
+      - uses: actions/checkout@v4
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install stable --profile minimal

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 The configuration app for the Ultimate-NAG52 TCU
 
+## Installation
+
+### macOS
+After downloading the `.app` bundle, you may need to remove the quarantine attribute due to the app not being signed with an Apple Developer Certificate:
+
+```bash
+xattr -cr Ultimate-NAG52-Config-App.app
+open Ultimate-NAG52-Config-App.app
+```
+
+Alternatively, right-click the app and select "Open" (first time only).
+
+### Windows
+Run the `.exe` file directly.
+
+### Linux
+Make the AppImage executable and run:
+```bash
+chmod +x Ultimate-NAG52-Config-App*.AppImage
+./Ultimate-NAG52-Config-App*.AppImage
+```
+
 ## Starting version 1.0.8
 to load the TCU Settings page, you will need `MODULE_SETTINGS.yml` file that is shipped with the TCUs firmware on Github!
 

--- a/config_app/Cargo.toml
+++ b/config_app/Cargo.toml
@@ -32,7 +32,7 @@ ehttp="0.5.0"
 octocrab = "0.45.0"
 tokio = { version = "1.45.1", features = ["full"] }
 zip="5.1.1"
-curl = "0.4.43"
+curl = { version = "0.4.43", features = ["static-curl", "static-ssl"] }
 egui_plot = "0.33.0"
 serde_derive = "1.0.197"
 lz4-compression = "0.7.0"


### PR DESCRIPTION
## Problem
macOS builds were failing on GitHub Actions since mid-2024 when macos-latest switched from Intel (x86_64) to Apple Silicon (ARM64) runners. The workflow was building only for the runner's native architecture, creating incompatible binaries for users with different Mac processors.

Additionally, cross-compilation from ARM64 to x86_64 failed due to OpenSSL requiring system libraries for the target architecture, which weren't available on the ARM64 build machine.

## Solution

### 1. Universal Binary Build Process
- Install both x86_64-apple-darwin and aarch64-apple-darwin Rust targets
- Build separate binaries for Intel and Apple Silicon architectures
- Use lipo to create a Universal Binary (fat binary) containing both
- Package the universal binary into .app bundle with cargo-bundle

This ensures the application runs natively on both Intel Macs and M1/M2/M3 processors without requiring Rosetta translation.

### 2. OpenSSL Cross-Compilation Fix
- Enable static-curl and static-ssl features for curl dependency
- This triggers openssl-src to compile OpenSSL from source for each target
- Set OPENSSL_STATIC=1 environment variable during builds
- Add build dependencies check for perl and make (required by OpenSSL build)

Static linking eliminates the need for target-specific system OpenSSL libraries during cross-compilation.

### 3. GitHub Actions Updates
- Update all actions from @v3 to @v4
- Replace deprecated actions/create-release with softprops/action-gh-release@v2
- Remove duplicate Rust installation in docs workflow
- Update rust-cache key to reflect new build configuration
- Add commented code signing section (requires Apple Developer Certificate)

### 4. Documentation
- Add Installation section to README with platform-specific instructions
- Document macOS quarantine attribute removal (xattr -cr) needed due to unsigned binaries (Apple Developer Certificate not yet available)

## Files Changed
- .github/workflows/build.yml: Universal binary build, OpenSSL config, updated actions
- .github/workflows/docs.yml: Updated checkout action, removed duplicate code
- config_app/Cargo.toml: Added static-curl and static-ssl features to curl
- README.md: Added installation instructions for all platforms

## Testing
Verified on GitHub Actions with macOS 15 (Apple Silicon) runner. Universal binary successfully created and verified with lipo.

## Future Improvements
- Add Apple Developer Certificate for code signing and notarization
- This will eliminate the need for users to run xattr commands
- See commented section in build.yml for implementation details