### PR TITLE
Fix cargo-bundle overwriting universal binary with single-architectur…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
     branches: [ "dev" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -98,13 +102,13 @@ jobs:
           OPENSSL_STATIC: "1"
       - name: Create Universal Binary
         run: |
-          mkdir -p target/release
+          mkdir -p target/universal
           lipo -create \
             target/x86_64-apple-darwin/release/config_app \
             target/aarch64-apple-darwin/release/config_app \
-            -output target/release/config_app
+            -output target/universal/config_app
           echo "Universal binary created. Verifying architectures:"
-          lipo -info target/release/config_app
+          lipo -info target/universal/config_app
       # TODO: Code signing with Apple Developer Certificate
       # Requires: Apple Developer Account ($99/year) and certificates in GitHub Secrets
       # Uncomment and configure the following steps when certificate is available:
@@ -133,14 +137,73 @@ jobs:
       # xattr -cr Ultimate-NAG52-Config-App.app
       - name: Create .app bundle with cargo-bundle
         run: |
-          # cargo-bundle expects binary in target/release/
+          # cargo-bundle will rebuild for host arch (ARM64) and may clean target/release/
+          # Our universal binary is safely stored in target/universal/
           cargo bundle --release --package config_app
+          echo "Bundle created. Now replacing with universal binary..."
+
+          # Verify universal binary still exists
+          if [ ! -f "target/universal/config_app" ]; then
+            echo "ERROR: Universal binary not found at target/universal/config_app"
+            exit 1
+          fi
+
+          # Replace the bundled binary with our universal binary
+          cp -v target/universal/config_app \
+             "target/release/bundle/osx/Ultimate-NAG52-Config-App.app/Contents/MacOS/config_app"
+
           echo "Bundle contents:"
-          ls -R target/release/bundle/osx/
+          ls -lh target/release/bundle/osx/Ultimate-NAG52-Config-App.app/Contents/MacOS/
+      - name: Verify Universal Binary in .app bundle
+        run: |
+          echo "Verifying that .app contains universal binary..."
+          LIPO_OUTPUT=$(lipo -info "target/release/bundle/osx/Ultimate-NAG52-Config-App.app/Contents/MacOS/config_app")
+          echo "$LIPO_OUTPUT"
+
+          # Check if output contains both architectures
+          if echo "$LIPO_OUTPUT" | grep -q "x86_64" && echo "$LIPO_OUTPUT" | grep -q "arm64"; then
+            echo "SUCCESS: Universal binary verified (x86_64 + arm64)"
+          else
+            echo "FAILURE: Binary is NOT universal!"
+            echo "Expected both 'x86_64' and 'arm64' in lipo output"
+            exit 1
+          fi
+      - name: Verify macOS deployment targets
+        run: |
+          echo "Checking minimum macOS version requirements..."
+          BINARY="target/release/bundle/osx/Ultimate-NAG52-Config-App.app/Contents/MacOS/config_app"
+
+          # Extract deployment target for each architecture
+          echo "=== x86_64 architecture ==="
+          X86_VERSION=$(otool -l "$BINARY" -arch x86_64 | grep -A 3 "LC_BUILD_VERSION\|LC_VERSION_MIN_MACOSX" | grep "minos\|version" | head -1 | awk '{print $2}')
+          echo "x86_64 minimum macOS: $X86_VERSION"
+
+          echo ""
+          echo "=== arm64 architecture ==="
+          ARM_VERSION=$(otool -l "$BINARY" -arch arm64 | grep -A 3 "LC_BUILD_VERSION\|LC_VERSION_MIN_MACOSX" | grep "minos\|version" | head -1 | awk '{print $2}')
+          echo "arm64 minimum macOS: $ARM_VERSION"
+
+          echo ""
+          echo "=== Summary ==="
+          if [ -n "$X86_VERSION" ] && [ -n "$ARM_VERSION" ]; then
+            REQUIRED_VERSION=$(echo -e "$X86_VERSION\n$ARM_VERSION" | sort -V | tail -1)
+            echo "Universal binary requires macOS $REQUIRED_VERSION or newer (highest of both architectures)"
+          else
+            echo "Could not determine deployment target versions"
+          fi
+      - name: Package .app as DMG
+        run: |
+          cd target/release/bundle/osx
+          hdiutil create -volname "Ultimate-NAG52-Config-App" \
+            -srcfolder Ultimate-NAG52-Config-App.app \
+            -ov -format UDZO \
+            config_app.dmg
+          ls -lh config_app.dmg
+          echo "DMG created successfully"
       - uses: actions/upload-artifact@v4
         with:
           name: config-app-osx
-          path: target/release/bundle/osx/*.app
+          path: target/release/bundle/osx/config_app.dmg
 
   Create-Upload:
     needs: [Windows-App, Linux-App, OSX-app]
@@ -172,7 +235,7 @@ jobs:
         files: |
           *.exe
           *.AppImage
-          Ultimate-NAG52-Config-App.app
+          *.dmg
       
           
        

--- a/README.md
+++ b/README.md
@@ -5,14 +5,31 @@ The configuration app for the Ultimate-NAG52 TCU
 ## Installation
 
 ### macOS
-After downloading the `.app` bundle, you may need to remove the quarantine attribute due to the app not being signed with an Apple Developer Certificate:
 
+#### ⚠️ IMPORTANT: App is not code-signed
+This app is not signed with an Apple Developer Certificate. macOS will show a security warning when you first try to open it.
+
+**DO NOT double-click the app on first launch** - it will show "app is damaged" error.
+
+#### Installation Steps:
+1. Download `config_app.dmg` from [Releases](https://github.com/rnd-ash/ultimate-nag52-config-app/releases)
+2. Open the downloaded DMG file
+3. Drag `Ultimate-NAG52-Config-App.app` to your **Applications** folder
+4. **Right-click** (or Control-click) on the app in Applications
+5. Select **"Open"** from the menu
+6. Click **"Open"** in the security dialog that appears
+
+**This is only needed the first time.** After that, you can launch the app normally.
+
+<details>
+<summary>Alternative: Using Terminal (for advanced users)</summary>
+
+If you prefer using the terminal:
 ```bash
-xattr -cr Ultimate-NAG52-Config-App.app
-open Ultimate-NAG52-Config-App.app
+xattr -cr /Applications/Ultimate-NAG52-Config-App.app
+open /Applications/Ultimate-NAG52-Config-App.app
 ```
-
-Alternatively, right-click the app and select "Open" (first time only).
+</details>
 
 ### Windows
 Run the `.exe` file directly.


### PR DESCRIPTION
…e build

## Problem
cargo-bundle automatically runs 'cargo build --release' for the host architecture before creating the .app bundle. On Apple Silicon runners (macos-latest since 2024), this rebuilds the binary for ARM64 only, overwriting the carefully crafted universal binary created with lipo.

Result: The .app bundle contained only ARM64 binary, making it incompatible with Intel Macs.

Additionally:
- Universal binary stored in target/release/ was overwritten by cargo-bundle
- .app bundle (directory) cannot be uploaded to GitHub releases directly
- Users without technical knowledge struggled with terminal-based xattr commands

## Solution

### 1. Isolate Universal Binary
Store universal binary in target/universal/ instead of target/release/ to prevent cargo-bundle from overwriting it during its build process:
- lipo creates universal binary in target/universal/config_app
- cargo-bundle cannot touch this location
- Safe from cleanup/rebuild operations

### 2. Replace Bundled Binary
After cargo-bundle creates .app structure:
- Verify target/universal/config_app exists (fail if missing)
- Copy universal binary to .app/Contents/MacOS/config_app
- This replaces cargo-bundle's ARM64-only binary with universal binary

### 3. Automated Verification
Added verification step that:
- Runs lipo -info on final bundled binary
- Checks for both 'x86_64' and 'arm64' architectures
- Fails workflow with exit 1 if binary is not universal
- Prevents deployment of broken single-architecture builds

### 4. Display Deployment Targets
Added informational step using otool to display:
- Minimum macOS version for x86_64 architecture (10.12.0)
- Minimum macOS version for arm64 architecture (11.0.0)
- Overall requirement (11.0.0 - highest of both)

This helps diagnose compatibility issues with older macOS versions.

### 5. DMG Packaging
Package .app as DMG disk image in OSX-app job (macOS runner):
- hdiutil creates compressed DMG (UDZO format) after .app verification
- DMG uploaded as artifact instead of .app directory
- Create-Upload job downloads and uploads DMG to release
- Standard macOS distribution format

### 6. User-Friendly Documentation
Updated README with clear installation instructions:
- Step-by-step guide using right-click → Open method
- No terminal commands required for basic installation
- xattr method moved to collapsible section for advanced users
- Clear warning about "DO NOT double-click" on first launch

## How config_app.dmg Works

### Distribution:
1. GitHub Actions builds universal binary (x86_64 + arm64)
2. cargo-bundle creates .app structure
3. Universal binary replaces bundled ARM64-only binary
4. .app is verified for both architectures
5. .app is packaged into config_app.dmg disk image on macOS runner
6. DMG is uploaded to GitHub release

### User Installation:
1. User downloads config_app.dmg
2. Opens DMG (mounts as read-only volume)
3. Drags Ultimate-NAG52-Config-App.app to Applications folder
4. Right-clicks app in Applications → "Open"
5. Confirms security dialog
6. App launches successfully (first time bypass complete)
7. Subsequent launches work with normal double-click

The right-click → Open method bypasses macOS Gatekeeper's initial block without requiring terminal commands or technical knowledge.

## Additional Changes
- Add workflow_dispatch for manual workflow triggering
- Add workflow permissions (contents: write) for release creation
- Update rust-cache key to v2-macos-universal-static-ssl

## Testing
Verified on GitHub Actions:
- Universal binary successfully created and verified with lipo
- Both architectures present in final .app bundle
- DMG packaging successful on macOS runner
- Deployment target verification working

## Release Assets
- config_app.exe (Windows 32-bit)
- config_app.AppImage (Linux)
- config_app.dmg (macOS Universal Binary - Intel + Apple Silicon)
  - Supports macOS 11.0 (Big Sur) or newer
  - Works natively on both Intel and Apple Silicon Macs