### PR TITLE
Fix status bar TX/RX repaint timing

### DIFF
--- a/config_app/src/window.rs
+++ b/config_app/src/window.rs
@@ -85,6 +85,7 @@ impl eframe::App for MainWindow {
         if stack_size > 0 {
             let mut pop_page = false;
             if self.show_sbar {
+                ctx.request_repaint_after(Duration::from_millis(100));
                 egui::TopBottomPanel::bottom("NAV").show(ctx, |nav| {
                     nav.horizontal(|row| {
                         egui::widgets::global_theme_preference_buttons(row);


### PR DESCRIPTION
## Summary
- request periodic UI repaint while the status bar is visible
- keep TX/RX activity indicators updating even when there is no mouse movement

## Motivation
On Linux, the TX/RX indicators in the bottom status bar only updated while the mouse was moving. If the pointer stayed still, the indicators either did not light up or stayed stuck in their last visible state.

## Testing
- tested locally on Linux
- verified TX/RX indicators update without mouse movement
