### PR TITLE
Align datalogger chart time axes

### DIFF
--- a/config_app/src/ui/diagnostics/mod.rs
+++ b/config_app/src/ui/diagnostics/mod.rs
@@ -19,6 +19,8 @@ use crate::ui::diagnostics::rli::{LocalRecordData, RecordIdents};
 
 use self::rli::ChartData;
 
+const CHART_Y_AXIS_MIN_WIDTH: f32 = 96.0;
+
 pub struct DiagnosticsPage {
     query_ecu: Arc<AtomicBool>,
     curr_values: Arc<RwLock<Option<LocalRecordData>>>,
@@ -221,8 +223,15 @@ impl crate::window::InterfacePage for DiagnosticsPage {
                     egui_extras::StripBuilder::new(col)
                         .sizes(Size::exact(space_per_chart), data.get_chart_data().len())
                         .vertical(|mut strip| {
-                            let plot_interval = self.graph_interval_ms.load(Ordering::Relaxed);
                             let plot_range = self.max_graph_time.load(Ordering::Relaxed);
+                            let now = self.launch_time.elapsed().as_millis() - start_time as u128;
+                            let x_max = now as f64;
+                            let x_min = (x_max - plot_range as f64).max(0.0);
+                            let x_max = if x_max <= x_min {
+                                x_min + 1.0
+                            } else {
+                                x_max
+                            };
 
                             for (idx, d) in data.get_chart_data().iter().enumerate() {
                                 strip.cell(|ui| {
@@ -236,19 +245,14 @@ impl crate::window::InterfacePage for DiagnosticsPage {
                                         lines.push(Line::new(format!("{} ({:.02} {})", key.clone(), points.points().last().map(|x| x.y).unwrap_or_default(), unit.unwrap_or_default()), points).stroke(Stroke::new(2.0, color.clone())).id(key.clone()));
                                     }
             
-                                    let now = self.launch_time.elapsed().as_millis() - start_time as u128;
-
-                                    let mut last_bound = now as f64 - plot_range as f64;
-                                    if last_bound < 0.0 {
-                                        last_bound = 0.0;
-                                    }
                                     let x = unit.clone();
-                                    let mut plot = Plot::new(d.group_name.clone())
+                                    let mut plot = Plot::new(format!("diagnostics-plot-{idx}-{}", d.group_name))
                                         //.height(space_per_chart)
                                         .allow_drag(false)
                                         .auto_bounds([false, true])
-                                        .include_x(last_bound)
-                                        .include_x(now as f64 - plot_interval as f64)
+                                        .include_x(x_min)
+                                        .include_x(x_max)
+                                        .y_axis_min_width(CHART_Y_AXIS_MIN_WIDTH)
                                         .legend(legend.clone())
                                         .x_axis_formatter(|f, _| {
                                             let seconds = f.value / 1000.0;


### PR DESCRIPTION
## Summary
- use a shared X-axis time range for datalogger charts
- reserve a consistent Y-axis label width so stacked plots line up

## Motivation
Datalogger plots could start at different horizontal positions because different Y-axis labels consumed different amounts of space. This made stacked charts visually misaligned even though they represented the same time window.

## Testing
- tested locally in the datalogger view
- verified stacked charts start at the same X position and show the same time range
